### PR TITLE
Add newlines to output

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -65,7 +65,7 @@ func (ctx *contextCmd) run() error {
 		return err
 	}
 
-	fmt.Fprintf(ctx.out, "successfully switched to context: %v", ctx.contextName)
+	fmt.Fprintf(ctx.out, "Successfully switched to context: %v\n", ctx.contextName)
 	return nil
 }
 

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -88,7 +88,7 @@ func (ns *namespaceCmd) run() (error) {
 		return err
 	}
 
-	fmt.Fprintf(ns.out, "successfully switched to namespace: %v", ns.namespace)
+	fmt.Fprintf(ns.out, "Successfully switched to namespace: %v\n", ns.namespace)
 	return nil
 }
 


### PR DESCRIPTION
Adds newlines to output to avoid having the prompt on the same line as the output.